### PR TITLE
Implement "Recently Added" view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -86,6 +86,7 @@ import SongCollection from './views/SongCollection.vue';
 import MyAlbums from './views/MyAlbums.vue';
 import MySongs from './views/MySongs.vue';
 import MyArtists from './views/MyArtists.vue';
+import RecentlyAdded from './views/RecentlyAdded';
 import Artist from './views/Artist.vue';
 import Search from './views/Search.vue';
 import Me from './views/Me.vue';
@@ -175,6 +176,18 @@ const routes = [
         component: SongCollection,
         meta: {
           type: 'album',
+          isLibrary: true
+        }
+      },
+      {
+        name: 'recently-added',
+        path: 'recently-added',
+        component: RecentlyAdded,
+        props: {
+          title: 'Recently Added'
+        },
+        meta: {
+          title: 'Recently Added',
           isLibrary: true
         }
       },

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -39,6 +39,7 @@
     <div v-if="isAuthorized">
       <h2 class="text-uppercase text-muted heading">My Library</h2>
       <b-list-group class="mb-2">
+        <b-list-group-item :to="{ name: 'recently-added' }" exact>Recently Added</b-list-group-item>
         <b-list-group-item :to="{ name: 'my-songs' }" exact>Songs</b-list-group-item>
         <b-list-group-item :to="{ name: 'my-albums' }" exact>Albums</b-list-group-item>
         <b-list-group-item :to="{ name: 'my-artists' }" exact>Artists</b-list-group-item>

--- a/src/views/RecentlyAdded.vue
+++ b/src/views/RecentlyAdded.vue
@@ -1,0 +1,116 @@
+
+<template>
+  <div>
+    <h1 v-if="title">{{ title }}</h1>
+
+    <SongCollectionList :items="items" showCount countLabel="item" v-if="items" />
+    <Loading message="Loading..." v-if="loading" />
+  </div>
+</template>
+
+<script>
+import Raven from 'raven-js';
+import EventBus from '../event-bus';
+
+import SongCollectionList from '../components/SongCollectionList.vue';
+import Loading from '../components/Loading.vue';
+
+export default {
+  name: 'RecentlyAdded',
+  components: {
+    SongCollectionList,
+    Loading
+  },
+  props: {
+    title: String
+  },
+  data: function () {
+    let musicKit = window.MusicKit.getInstance();
+
+    return {
+      musicKit: musicKit,
+      items: null
+    };
+  },
+  methods: {
+    fetch: function (offset) {
+      if (this.abort) {
+        return;
+      }
+
+      this.loading = true;
+
+      if (!offset) {
+        offset = 0;
+      }
+
+      this.musicKit.api.library.collection('recently-added', null, { offset: offset, limit: 10 })
+        .then(r => {
+          if (!this.items) {
+            this.items = r;
+          } else {
+            this.items = this.items.concat(r);
+          }
+
+          if (r.length !== 0) {
+            this.fetch(offset + 10);
+          } else {
+            this.loading = false;
+          }
+        }, err => {
+          Raven.captureException(err);
+
+          EventBus.$emit('alert', {
+            type: 'danger',
+            message: `An unexpected error occurred.`
+          });
+        });
+    }
+  },
+  created: function () {
+    this.fetch();
+  },
+  destroyed: function () {
+    this.abort = true;
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+  a:hover {
+    text-decoration: none;
+  }
+
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .grid .item {
+    width: 200px;
+    margin: 5px;
+    font-size: 0.9em;
+  }
+
+  .item img {
+    width: 200px;
+    height: 200px;
+    border-radius: 4px;
+    margin-bottom: 4px;
+    box-shadow: 0 0 1px rgba(0, 0, 0, .4);
+  }
+
+  .item span {
+    display: block;
+    padding: 1px 6px;
+    color: black;
+  }
+</style>
+
+<style>
+  .song-cell {
+    vertical-align: middle !important;
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
There's an endpoint in the Apple Music API for retrieving up to 150 recently added items, it just isn't exposed through its own method in MusicKit.

https://developer.apple.com/documentation/applemusicapi/get_recently_added

The component is almost identical to the albums component, could really do with sharing a component which just takes in a fetch method.

The max limit for fetching is 10 rather than 100 for this method.

Fixes #14