### PR TITLE
 Implement lazy image loading for album/song lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap-vue": "^2.0.0-rc.11",
     "bootswatch": "^4.1.1",
     "font-awesome": "^4.7.0",
+    "intersection-observer": "^0.5.0",
     "moment": "^2.22.2",
     "raven-js": "^3.26.4",
     "vue": "^2.5.16",

--- a/src/components/LazyImg.vue
+++ b/src/components/LazyImg.vue
@@ -1,0 +1,33 @@
+
+<template>
+  <img :data-src="src" src="//:0" :alt="alt" />
+</template>
+
+<script>
+import 'intersection-observer'; // Polyfill
+
+const intersectionObserver = new IntersectionObserver(function (entries) {
+  for (const entry of entries) {
+    const img = entry.target;
+    if (entry.isIntersecting) {
+      img.src = img.getAttribute('data-src');
+    } else {
+      img.src = '//:0';
+    }
+  }
+}, {rootMargin: '100%'});
+
+export default {
+  name: 'LazyImg',
+  props: {
+    src: String,
+    alt: String
+  },
+  mounted: function () {
+    intersectionObserver.observe(this.$el);
+  },
+  destroyed: function () {
+    intersectionObserver.unobserve(this.$el);
+  }
+};
+</script>

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -43,7 +43,7 @@
                                     v-if="queueTab == 1 ? index > queuePosition : queue.length - 1 - index < queuePosition">
                      <div class="queue-item">
                         <div class="mr-2">
-                           <img v-if="item.attributes.artwork"
+                           <lazy-img v-if="item.attributes.artwork"
                                  :src="formatArtworkURL(item.attributes.artwork, 40, 40)" />
                         </div>
                         <div class="m-0 grow-1">
@@ -75,9 +75,11 @@
 import EventBus from '../event-bus';
 import moment from 'moment';
 import Raven from 'raven-js';
+import LazyImg from './LazyImg';
 
 export default {
   name: 'NowPlaying',
+  components: {LazyImg},
   data: function () {
     let musicKit = window.MusicKit.getInstance();
 

--- a/src/components/SongCollectionList.vue
+++ b/src/components/SongCollectionList.vue
@@ -6,7 +6,7 @@
     <div class="grid">
       <div class="item" v-for="item in items" :key="item.id">
         <router-link :to="{ name: item.type, params: { id: item.id } }">
-          <img :src="formatArtworkURL(item.attributes.artwork)" alt="" v-if="item.attributes.artwork" />
+          <lazy-img :src="formatArtworkURL(item.attributes.artwork)" alt="" v-if="item.attributes.artwork" />
           <div class="artwork-placeholder" v-else></div>
 
           <span>{{ item.attributes.name }}</span>
@@ -19,9 +19,11 @@
 
 <script>
 import moment from 'moment';
+import LazyImg from './LazyImg';
 
 export default {
   name: 'SongCollectionList',
+  components: {LazyImg},
   props: {
     showCount: Boolean,
     countLabel: String,
@@ -68,8 +70,10 @@ a:hover {
 }
 
 .item img, .artwork-placeholder {
+  display: block;
   width: 200px;
   height: 200px;
+  object-fit: contain;
   border-radius: 4px;
   margin-bottom: 4px;
   box-shadow: 0 0 1px rgba(0, 0, 0, .4);

--- a/src/components/SongCollectionList.vue
+++ b/src/components/SongCollectionList.vue
@@ -6,7 +6,7 @@
     <div class="grid">
       <div class="item" v-for="item in items" :key="item.id">
         <router-link :to="{ name: item.type, params: { id: item.id } }">
-          <lazy-img :src="formatArtworkURL(item.attributes.artwork)" alt="" v-if="item.attributes.artwork" />
+          <lazy-img :src="formatArtworkURL(item.attributes.artwork, 200, 200)" alt="" v-if="item.attributes.artwork" />
           <div class="artwork-placeholder" v-else></div>
 
           <span>{{ item.attributes.name }}</span>

--- a/src/components/Songs.vue
+++ b/src/components/Songs.vue
@@ -6,7 +6,7 @@
 
     <b-table :items="songs" :fields="fields" hover v-on:row-clicked="clicked">
       <template slot="attributes.artwork" slot-scope="data">
-        <img v-if="data.value && data.value.artwork"
+        <lazy-img v-if="data.value && data.value.artwork"
              :src="formatArtworkURL(data.value.artwork, 40, 40)"
              :class="{ 'playing': data.value.playing }" />
       </template>
@@ -37,9 +37,11 @@
 import Raven from 'raven-js';
 import EventBus from '../event-bus';
 import moment from 'moment';
+import LazyImg from './LazyImg';
 
 export default {
   name: 'Songs',
+  components: {LazyImg},
   props: {
     title: String,
     songs: Array


### PR DESCRIPTION
Adds LazyImg component which only sets img src when an image is within 1 viewport of being on screen.

Should reduce memory usage for long lists (e.g. big libraries) and prevents hundreds/thousands of network requests being made for album art simultaneously.

Sets `display: block` on `.item img` as without this the `width/height: 200px;` has no effect. Adds `object-fit: contain` to avoid stretching non-square images.

The LazyImg component uses a singleton `IntersectionObserver` at the module level which isn't ideal but I'm new to Vue and not sure the best way to deal with singletons like this.