### PR TITLE
Add play button for albums/playlists in SongCollectionList, shown on hover

### DIFF
--- a/src/components/SongCollectionList.vue
+++ b/src/components/SongCollectionList.vue
@@ -23,7 +23,7 @@
 <script>
 import moment from 'moment';
 import LazyImg from './LazyImg';
-import Raven from 'raven-js';
+import {playItem} from '../utils';
 
 export default {
   name: 'SongCollectionList',
@@ -52,16 +52,7 @@ export default {
     formatArtworkURL: function (url, height, width) {
       return window.MusicKit.formatArtworkURL(url, width, width);
     },
-    play: function (item) {
-      this.musicKit.setQueue({
-        [item.attributes.playParams.kind]: item.attributes.playParams.id
-      }).then(queue => {
-        queue.items.forEach(i => { i.sourceId = i.id; });
-        this.musicKit.play();
-      }, err => {
-        Raven.captureException(err);
-      });
-    }
+    play: playItem
   }
 };
 </script>

--- a/src/components/SongCollectionList.vue
+++ b/src/components/SongCollectionList.vue
@@ -12,6 +12,9 @@
           <span>{{ item.attributes.name }}</span>
           <span class="text-muted">{{ item.attributes.curatorName || item.attributes.artistName }}</span>
         </router-link>
+        <button class="play-button" v-on:click="play(item)">
+          <i class="fa fa-play"></i>
+        </button>
       </div>
     </div>
   </div>
@@ -20,6 +23,7 @@
 <script>
 import moment from 'moment';
 import LazyImg from './LazyImg';
+import Raven from 'raven-js';
 
 export default {
   name: 'SongCollectionList',
@@ -47,6 +51,16 @@ export default {
   methods: {
     formatArtworkURL: function (url, height, width) {
       return window.MusicKit.formatArtworkURL(url, width, width);
+    },
+    play: function (item) {
+      this.musicKit.setQueue({
+        [item.attributes.playParams.kind]: item.attributes.playParams.id
+      }).then(queue => {
+        queue.items.forEach(i => { i.sourceId = i.id; });
+        this.musicKit.play();
+      }, err => {
+        Raven.captureException(err);
+      });
     }
   }
 };
@@ -64,6 +78,7 @@ a:hover {
   justify-content: flex-start;
 }
 .grid .item {
+  position: relative;
   width: 200px;
   margin: 5px;
   font-size: 0.9em;
@@ -77,6 +92,31 @@ a:hover {
   border-radius: 4px;
   margin-bottom: 4px;
   box-shadow: 0 0 1px rgba(0, 0, 0, .4);
+}
+
+.item .play-button {
+  background-color: rgba(255, 255, 255, .8);
+  border: none;
+  border-radius: 50%;
+  color: #2e8af7;
+  display: none;
+  font-size: 18px;
+  height: 32px;
+  left: 10px;
+  line-height: 32px;
+  outline: none;
+  padding-left: 9px;
+  position: absolute;
+  top: 158px;
+  width: 32px;
+}
+
+.item .play-button:active {
+  background-color: rgba(220, 220, 220, 0.8);
+}
+
+.item:hover .play-button {
+  display: block;
 }
 
 .artwork-placeholder {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,18 @@
+import Raven from 'raven-js';
+
+/**
+ * Sets the queue to a single item and starts playback.
+ * @param item A single MusicKit entity with {@code attributes.playParams}.
+ */
+export function playItem (item) {
+  const musicKit = window.MusicKit.getInstance();
+  const playParams = item.attributes.playParams;
+  musicKit.setQueue({
+    [playParams.kind]: playParams.id
+  }).then(queue => {
+    queue.items.forEach(i => { i.sourceId = i.id; });
+    musicKit.play();
+  }, err => {
+    Raven.captureException(err);
+  });
+}

--- a/src/views/SongCollection.vue
+++ b/src/views/SongCollection.vue
@@ -31,6 +31,7 @@ import moment from 'moment';
 
 import Songs from '../components/Songs.vue';
 import Loading from '../components/Loading.vue';
+import {playItem} from '../utils';
 
 export default {
   name: 'SongCollection',
@@ -108,14 +109,7 @@ export default {
       });
     },
     play: function () {
-      this.musicKit.setQueue({
-        [this.collection.attributes.playParams.kind]: this.collection.attributes.playParams.id
-      }).then(queue => {
-        queue.items.forEach(i => { i.sourceId = i.id; });
-        this.musicKit.play();
-      }, err => {
-        Raven.captureException(err);
-      });
+      playItem(this.collection);
     },
     shuffle: function () {
       // Temporary shuffle implementation until supported in MusicKit JS.


### PR DESCRIPTION
Matches the behaviour in iTunes. Makes it easy to start playback of a full album/playlist without drilling down into it.

![image](https://user-images.githubusercontent.com/930324/44957323-0cba5e00-aec9-11e8-8e03-a56d8238d546.png)