### PR TITLE
Remove redundant queue seek on song play

### DIFF
--- a/src/components/Songs.vue
+++ b/src/components/Songs.vue
@@ -100,18 +100,8 @@ export default {
         this.musicKit.setQueue({
           items: this.songs.map(i => this.trackToMediaItem(i)),
           startPosition: this.songs.indexOf(item)
-        }).then(queue => {
-          this.musicKit.player.changeToMediaItem(queue.item(this.songs.indexOf(item)))
-            .then(r => {
-              this.musicKit.play().catch(err => console.error(err));
-            }, err => {
-              Raven.captureException(err);
-
-              EventBus.$emit('alert', {
-                type: 'danger',
-                message: `An unexpected error occurred.`
-              });
-            });
+        }).then(() => {
+          this.musicKit.play().catch(err => console.error(err));
         }, err => {
           Raven.captureException(err);
 


### PR DESCRIPTION
Seeking to the correct initial track is already handled by the `startPosition` parameter.

I tested this locally and couldn't see any change in behaviour, but I'm guessing you added it for a reason - feel free to close without merging if it's necessary.