### PR TITLE
Replace all 'moment' usage with MusicKit methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,11 +7117,6 @@
         "minimist": "0.0.8"
       }
     },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "bootswatch": "^4.1.1",
     "font-awesome": "^4.7.0",
     "intersection-observer": "^0.5.0",
-    "moment": "^2.22.2",
     "raven-js": "^3.26.4",
     "vue": "^2.5.16",
     "vue-localstorage": "^0.6.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -94,7 +94,7 @@ import NotFound from './views/NotFound.vue';
 import Settings from './views/Settings.vue';
 import Debug from './views/Debug.vue';
 
-import moment from 'moment';
+import {formatMillis} from './utils';
 
 // Initialize router
 const routes = [
@@ -357,19 +357,6 @@ export default {
     }
   },
   methods: {
-    formatDuration: function (value, unit) {
-      let pad = function (num) {
-        if (num < 10) {
-          num = '0' + num;
-        }
-
-        return num;
-      };
-
-      let m = moment.duration(value, unit);
-
-      return m.minutes() + ':' + pad(m.seconds());
-    },
     alertCountdownChanged: function (count) {
       this.alert.countdown = count;
     }
@@ -440,7 +427,7 @@ export default {
 
             this.notification = new window.Notification(event.item.attributes.name, {
               tag: 'currentMediaItem',
-              body: event.item.attributes.artistName + ' (' + this.formatDuration(event.item.attributes.durationInMillis) + ')',
+              body: `${event.item.attributes.artistName} (${formatMillis(event.item.attributes.durationInMillis)})`,
               icon: event.item.attributes.artwork ? window.MusicKit.formatArtworkURL(event.item.attributes.artwork) : null
             });
 

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -24,7 +24,7 @@
          </div>
 
          <div class="right">
-            <span>{{ playbackTime.currentPlaybackTime | formattedDuration('seconds') }} / {{ playbackTime.currentPlaybackDuration | formattedDuration('seconds') }}</span>
+            <span>{{ playbackTime.currentPlaybackTime | formatSeconds }} / {{ playbackTime.currentPlaybackDuration | formatSeconds }}</span>
          </div>
 
          <div class="queue">
@@ -51,7 +51,7 @@
                            <p class="m-0 text-muted">{{ item.attributes.albumName }}</p>
                         </div>
                         <div class="m-0 text-right text-muted">
-                           {{ item.attributes.durationInMillis | formattedDuration }}
+                           {{ item.attributes.durationInMillis | formatMillis }}
                         </div>
                      </div>
                  </b-list-group-item>
@@ -73,9 +73,9 @@
 
 <script>
 import EventBus from '../event-bus';
-import moment from 'moment';
 import Raven from 'raven-js';
 import LazyImg from './LazyImg';
+import {formatMillis, formatSeconds} from '../utils';
 
 export default {
   name: 'NowPlaying',
@@ -99,19 +99,8 @@ export default {
     };
   },
   filters: {
-    formattedDuration: function (value, unit) {
-      let pad = function (num) {
-        if (num < 10) {
-          num = '0' + num;
-        }
-
-        return num;
-      };
-
-      let m = moment.duration(value, unit);
-
-      return m.minutes() + ':' + pad(m.seconds());
-    }
+    formatSeconds,
+    formatMillis
   },
   methods: {
     addToLibrary: function (item) {
@@ -130,19 +119,6 @@ export default {
           message: `An error occurred while adding "${item.attributes.name}" to your library.`
         });
       });
-    },
-    formatDuration: function (value, unit) {
-      let pad = function (num) {
-        if (num < 10) {
-          num = '0' + num;
-        }
-
-        return num;
-      };
-
-      let m = moment.duration(value, unit);
-
-      return m.minutes() + ':' + pad(m.seconds());
     },
     formatArtworkURL: function (url, height, width) {
       return window.MusicKit.formatArtworkURL(url, width, width);

--- a/src/components/SongCollectionList.vue
+++ b/src/components/SongCollectionList.vue
@@ -21,7 +21,6 @@
 </template>
 
 <script>
-import moment from 'moment';
 import LazyImg from './LazyImg';
 import {playItem} from '../utils';
 
@@ -32,13 +31,6 @@ export default {
     showCount: Boolean,
     countLabel: String,
     items: Array
-  },
-  computed: {
-  },
-  filters: {
-    humanize: function (value, unit) {
-      return moment.duration(value, unit).humanize();
-    }
   },
   data: function () {
     let musicKit = window.MusicKit.getInstance();

--- a/src/components/Songs.vue
+++ b/src/components/Songs.vue
@@ -73,9 +73,7 @@ export default {
     }
   },
   filters: {
-    humanize: function (value, unit) {
-      return moment.duration(value, unit).humanize();
-    }
+    humanize
   },
   data: function () {
     let musicKit = window.MusicKit.getInstance();

--- a/src/components/Songs.vue
+++ b/src/components/Songs.vue
@@ -49,8 +49,8 @@
 <script>
 import Raven from 'raven-js';
 import EventBus from '../event-bus';
-import moment from 'moment';
 import LazyImg from './LazyImg';
+import {formatMillis, humanize} from '../utils';
 
 export default {
   name: 'Songs',
@@ -88,19 +88,6 @@ export default {
   methods: {
     formatArtworkURL: function (url, height, width) {
       return window.MusicKit.formatArtworkURL(url, width, width);
-    },
-    formatDuration: function (value, unit) {
-      let pad = function (num) {
-        if (num < 10) {
-          num = '0' + num;
-        }
-
-        return num;
-      };
-
-      let m = moment.duration(value, unit);
-
-      return m.minutes() + ':' + pad(m.seconds());
     },
     clicked: function (item, index, event) {
       this.play(item);
@@ -191,7 +178,7 @@ export default {
       { key: 'attributes.trackNumber', label: '', tdClass: 'song-cell' },
       { key: 'name', label: 'Title' + (this.showArtist ? '<br>Artist' : ''), tdClass: 'song-cell' },
       { key: 'attributes.albumName', label: 'Album', tdClass: 'song-cell' },
-      { key: 'attributes.durationInMillis', label: 'Time', tdClass: 'song-cell', formatter: (value, key, item) => this.formatDuration(value) },
+      { key: 'attributes.durationInMillis', label: 'Time', tdClass: 'song-cell', formatter: value => formatMillis(value) },
       { key: 'actions', label: '', tdClass: 'actions-cell' }
     ];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,3 +16,31 @@ export function playItem (item) {
     Raven.captureException(err);
   });
 }
+
+/**
+ * Returns a humanized media duration string for a {@code value} in
+ * milliseconds.
+ */
+export function humanize (value) {
+  const duration = window.MusicKit.formattedMilliseconds(value);
+  if (duration.hours === 0 && duration.minutes === 0) {
+    return 'No items';
+  }
+  if (duration.hours >= 24) {
+    const days = (duration.hours + duration.minutes / 60) / 24;
+    const dayString = days.toFixed(1).replace('.0', '');
+    return `${dayString} day` + (dayString === '1' ? '' : 's');
+  }
+  let hours = '';
+  if (duration.hours > 0) {
+    hours = `${duration.hours} hour` + (duration.hours > 1 ? 's' : '');
+  }
+  let mins = '';
+  if (duration.minutes > 0) {
+    mins = `${duration.minutes} minute` + (duration.minutes > 1 ? 's' : '');
+  }
+  if (hours && mins) {
+    return `${hours}, ${mins}`;
+  }
+  return hours + mins;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,3 +44,18 @@ export function humanize (value) {
   }
   return hours + mins;
 }
+
+/**
+ * Returns a formatted media duration string for a {@code value} in seconds.
+ */
+export function formatSeconds (value) {
+  return window.MusicKit.formatMediaTime(value);
+}
+
+/**
+ * Returns a formatted media duration string for a {@code value} in
+ * milliseconds.
+ */
+export function formatMillis (value) {
+  return window.MusicKit.formatMediaTime(value / 1000);
+}

--- a/src/views/SongCollection.vue
+++ b/src/views/SongCollection.vue
@@ -28,7 +28,6 @@
 <script>
 import Raven from 'raven-js';
 import EventBus from '../event-bus';
-import moment from 'moment';
 
 import Songs from '../components/Songs.vue';
 import Loading from '../components/Loading.vue';
@@ -36,11 +35,6 @@ import {playItem} from '../utils';
 
 export default {
   name: 'SongCollection',
-  filters: {
-    formattedDuration: function (value, unit) {
-      return moment.duration(value, unit).humanize();
-    }
-  },
   components: {
     Songs,
     Loading


### PR DESCRIPTION
MusicKit has built in duration parsing (for going from seconds/milliseconds to hh:mm:ss or to an object with seconds and minutes keys).

This replaces all moment usages and removes the dependency. Fewer dependencies, less to break, smaller binary. Woo!